### PR TITLE
Fix of debug problem: entry point was not found

### DIFF
--- a/debugger.cpp
+++ b/debugger.cpp
@@ -165,7 +165,7 @@ void Debugger::processMessage(QString output, QString error)
     }
 
     if (c == 1) {
-	if (error.indexOf("error",0,Qt::CaseInsensitive)!=-1) {
+	if (error.indexOf("No symbol table is loaded",0,Qt::CaseInsensitive)!=-1) {
             dbgSymbols = false;
         } else {
             dbgSymbols = true;

--- a/debugger.cpp
+++ b/debugger.cpp
@@ -165,7 +165,7 @@ void Debugger::processMessage(QString output, QString error)
     }
 
     if (c == 1) {
-        if (error.isEmpty()) {
+	if (error.indexOf("error",0,Qt::CaseInsensitive)!=-1) {
             dbgSymbols = false;
         } else {
             dbgSymbols = true;

--- a/debugger.cpp
+++ b/debugger.cpp
@@ -165,7 +165,7 @@ void Debugger::processMessage(QString output, QString error)
     }
 
     if (c == 1) {
-        if (!error.isEmpty()) {
+        if (error.isEmpty()) {
             dbgSymbols = false;
         } else {
             dbgSymbols = true;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/12379081/8105941/05e8288e-1046-11e5-8eb7-3b0d9bc4838f.png)
Actually it is plain project, so it should compile & debug correctly.
At first, error was generated due to localization problem https://github.com/Dman95/SASM/issues/30
After fixing it, there was still the same error.
in the code of sasm, I found a line which produces an error:
```cpp
if (dbgSymbols)
    mainOffset = assembler->getMainOffset(lst, "main");
else
    mainOffset = assembler->getMainOffset(lst, "start");
```
to normally run debug, program should go into the first if, cause debugging symbols WERE generated
![image](https://cloud.githubusercontent.com/assets/12379081/8106098/2aefa25a-1047-11e5-9b82-b08fd567b8b3.png)
variable "dbgSymbols" was set only once, here:
```cpp
    if (c == 1) {
	if (!error.isEmpty()) {
            dbgSymbols = false;
        } else {
            dbgSymbols = true;
        }
    }
```
so I thought it must be an error in "!", removed it and got debug working:
![image](https://cloud.githubusercontent.com/assets/12379081/8106297/a193e2b2-1048-11e5-8af9-2c895b71a0ac.png)
but after https://github.com/Dman95/SASM/pull/34  I understand smth was wrong and found the content of "error" string:
```
warning: /etc/gdbinit.d/gdb-heap.py: No such file or directory
```
So I'm not sure, but maybe program should search for an actual error instead of just checking for an empty string? If not, please find another solution of this problem.