### PR TITLE
Update dependencies list by qt4-qmake libqt4-dev

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -16,6 +16,8 @@ You need:
 	gcc (x86) or gcc-multilib (x64)
 	gdb
 	nasm
+	qt4-qmake
+	libqt4-dev
 	libqt4-core 	
 	libqt4-gui
 	libxcb1


### PR DESCRIPTION
Hello @Dman95 ,

I tried building SASM on my Ubuntu 14.04:

```plain
$ lsb_release -a
Distributor ID:	Ubuntu
Description:	Ubuntu 14.04.3 LTS
Release:	14.04
Codename:	trusty
```

I installed the packages listed in README by doing:

```plain
$ sudo apt-get install gcc gdb nasm libqt4-core libqt4-gui libxcb1 libxcb-render0 libxcb-icccm4
```

But when I ran ```qmake``` I get the following error:

```plain
$ qmake
qmake: could not exec '/usr/lib/x86_64-linux-gnu/qt4/bin/qmake': No such file or directory
```

I fixed this by installing ```qt4-qmake```:

```plain
$ sudo apt-get install qt4-qmake
```

Then, after successfully running ```qmake``` and ```make install``` I get this error:

```plain
$ make install
/usr/lib/x86_64-linux-gnu/qt4/bin/uic settings.ui -o ui_settings.h
make: /usr/lib/x86_64-linux-gnu/qt4/bin/uic: Command not found
make: *** [ui_settings.h] Error 127
```

Which I fixed by installing ```libqt4-dev```:

```plain
$ sudo apt-get install libqt4-dev
```

This pull request is to address these errors by adding required packages in the README, so anyone trying the same building procedure does not have to google the solution.

Now, after I run:

```plain
$ sudo make install
```

Everything works well and I can run SASM.