### PR TITLE
Typos: Russian - the language - is "Russisch" in German.

### DIFF
--- a/language_de.ts
+++ b/language_de.ts
@@ -781,7 +781,7 @@
     <message>
         <location filename="settings.ui" line="138"/>
         <source>Russian (Русский)</source>
-        <translation>Russe (Русский)</translation>
+        <translation>Russisch (Русский)</translation>
     </message>
     <message>
         <location filename="settings.ui" line="143"/>
@@ -800,8 +800,8 @@
     </message>
     <message>
         <location filename="settings.ui" line="158"/>
-        <source>German (Deutsche)</source>
-        <translation>Deutsche</translation>
+        <source>German (Deutsch)</source>
+        <translation>Deutsch</translation>
     </message>
     <message>
         <location filename="settings.ui" line="181"/>

--- a/language_ru.ts
+++ b/language_ru.ts
@@ -1002,8 +1002,8 @@ WMR - R331674303467</translation>
     </message>
     <message>
         <location filename="settings.ui" line="158"/>
-        <source>German (Deutsche)</source>
-        <translation>Немецкий (Deutsche)</translation>
+        <source>German (Deutsch)</source>
+        <translation>Немецкий (Deutsch)</translation>
     </message>
     <message>
         <location filename="settings.ui" line="190"/>

--- a/language_tr.ts
+++ b/language_tr.ts
@@ -802,8 +802,8 @@
     </message>
     <message>
         <location filename="settings.ui" line="158"/>
-        <source>German (Deutsche)</source>
-        <translation>Almanca (Deutsche)</translation>
+        <source>German (Deutsch)</source>
+        <translation>Almanca (Deutsch)</translation>
     </message>
     <message>
         <location filename="settings.ui" line="181"/>

--- a/language_zh.ts
+++ b/language_zh.ts
@@ -800,8 +800,8 @@
     </message>
     <message>
         <location filename="settings.ui" line="158"/>
-        <source>German (Deutsche)</source>
-        <translation>德语 (Deutsche)</translation>
+        <source>German (Deutsch)</source>
+        <translation>德语 (Deutsch)</translation>
     </message>
     <message>
         <location filename="settings.ui" line="181"/>

--- a/main.cpp
+++ b/main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
         QPushButton *engButton = msgBox.addButton(QString("English"), QMessageBox::NoRole);
         QPushButton *turButton = msgBox.addButton(QString("Türk"), QMessageBox::NoRole);
         QPushButton *chiButton = msgBox.addButton(QString("中国"), QMessageBox::NoRole);
-        QPushButton *gerButton = msgBox.addButton(QString("Deutsche"), QMessageBox::NoRole);
+        QPushButton *gerButton = msgBox.addButton(QString("Deutsch"), QMessageBox::NoRole);
         msgBox.setWindowTitle(QString("Choose language"));
         msgBox.setText(QString("Choose language / Выберите язык / Dil seçin / 选择你的语言 / Sprache auswählen"));
         msgBox.exec();

--- a/settings.ui
+++ b/settings.ui
@@ -155,7 +155,7 @@
               </item>
               <item>
                <property name="text">
-                <string>German (Deutsche)</string>
+                <string>German (Deutsch)</string>
                </property>
               </item>
              </widget>


### PR DESCRIPTION
Also, "German" in German is "Deutsch", not "Deutsche".

It could be "Deutsche Sprache" (nemetski yasik).

"Deutsche" would either mean "German people (indefinite)" or "a German female".