### PR TITLE
Do not segfault when background is right-clicked in debugtablewidget

### DIFF
--- a/debugtablewidget.cpp
+++ b/debugtablewidget.cpp
@@ -226,7 +226,10 @@ void DebugTableWidget::closeEvent(QCloseEvent *) {
 void DebugTableWidget::mousePressEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::RightButton && type == memoryTable) {
-        contextMenuLineNumber = itemAt(event->pos())->row();
+        QTableWidgetItem *clicked_item = itemAt(event->pos());
+        if (!clicked_item) // background clicked
+            return;
+        contextMenuLineNumber = clicked_item->row();
         setCurrentCell(contextMenuLineNumber, 0);
         if (contextMenuLineNumber >= rowCount() - 1) //last line
             return;


### PR DESCRIPTION
This is a trivial bugfix.

How to test:
- Start sasm.
- Start debugging.
- Enable show memory.
- Rightclick the background there.
- Before: A segfault happens.
After: Nothing happens.

Probably fixes #128.