### PR TITLE
Pass -dead_strip -dead_strip_dylibs -bind_at_load on macOS

### DIFF
--- a/SASM.pro
+++ b/SASM.pro
@@ -11,6 +11,10 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = sasm
 TEMPLATE = app
 
+mac: LIBS+= -Wl,-dead_strip
+mac: LIBS+= -Wl,-dead_strip_dylibs
+mac: LIBS+= -Wl,-bind_at_load
+
 isEmpty(PREFIX) {
  PREFIX = /usr
 }


### PR DESCRIPTION
From `man ld`:
```
-dead_strip
                 Remove functions and data that are unreachable by the entry point or exported symbols.
```
```
-dead_strip_dylibs
                 Remove dylibs that are unreachable by the entry point or exported symbols. That is, suppresses the generation of load
                 command commands for dylibs which supplied no symbols during the link. This option should not be used when linking
                 against a dylib which is required at runtime for some indirect reason such as the dylib has an important initializer.
```
```
-bind_at_load
                 Sets a bit in the mach header of the resulting binary which tells dyld to bind all symbols when the binary is loaded,
                 rather than lazily.
```

Before:
```
% wc -c sasm.app/Contents/MacOS/sasm 
 1694052 sasm.app/Contents/MacOS/sasm

% otool -l sasm.app/Contents/MacOS/sasm 
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 1540096
    rebase_size 256
       bind_off 1540352
      bind_size 14520
  weak_bind_off 1554872
 weak_bind_size 768
  lazy_bind_off 1555640
 lazy_bind_size 26528
     export_off 1582168
    export_size 15552

% otool -L sasm.app/Contents/MacOS/sasm
sasm.app/Contents/MacOS/sasm:
	/opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 1894.10.126)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 212.2.3)
	/opt/local/libexec/qt5/lib/QtNetwork.framework/Versions/5/QtNetwork (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```
After:
```
% wc -c sasm.app/Contents/MacOS/sasm
 1675908 sasm.app/Contents/MacOS/sasm

% otool -l sasm.app/Contents/MacOS/sasm
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 1527808
    rebase_size 256
       bind_off 1528064
      bind_size 38184
  weak_bind_off 1566248
 weak_bind_size 768
  lazy_bind_off 0
 lazy_bind_size 0
     export_off 1567016
    export_size 14640

% otool -L sasm.app/Contents/MacOS/sasm
sasm.app/Contents/MacOS/sasm:
	/opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtNetwork.framework/Versions/5/QtNetwork (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```